### PR TITLE
Use latest version of cvelint

### DIFF
--- a/.github/workflows/cvelint.yml
+++ b/.github/workflows/cvelint.yml
@@ -25,7 +25,8 @@ jobs:
         
     - name: Grab Needed Data
       run: |
-          git clone --depth 1 https://github.com/CVEProject/cvelistV5 
+        wget https://github.com/CVEProject/cvelistV5/archive/refs/heads/main.tar.gz
+          mkdir -p cvelistV5 && tar xzf main.tar.gz --strip-component=1 --directory=./cvelistV5
          
     - name: Run CVELINT
       env:

--- a/.github/workflows/cvelint.yml
+++ b/.github/workflows/cvelint.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Install CVELINT
       run: |
-        wget https://github.com/mprpic/cvelint/releases/download/v0.1.0/cvelint_Linux_x86_64.tar.gz
+        wget https://github.com/mprpic/cvelint/releases/latest/download/cvelint_Linux_x86_64.tar.gz
           tar -xvf cvelint_Linux_x86_64.tar.gz
           chmod +x cvelint
           ./cvelint -h

--- a/.github/workflows/cvelint.yml
+++ b/.github/workflows/cvelint.yml
@@ -25,14 +25,14 @@ jobs:
         
     - name: Grab Needed Data
       run: |
-          git clone https://github.com/CVEProject/cvelistV5 
+          git clone --depth 1 https://github.com/CVEProject/cvelistV5 
          
     - name: Run CVELINT
       env:
         GH_TOKEN:  ${{ secrets.GH_TOKEN }}
       run: |
-          ./cvelint -format csv ./cvelistV5/cves > CVEV5Errors.csv
-          ./cvelint -format json ./cvelistV5/cves > CVEV5Errors.json
+          ./cvelint -format csv ./cvelistV5/cves > CVEV5Errors.csv 2>/dev/null
+          ./cvelint -format json ./cvelistV5/cves > CVEV5Errors.json 2>/dev/null
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This ensures the lint results in this repo stay current with the latest checks without having to bump the cvelint version on every release. Note that this still downloads a released version of cvelint, not just whatever is on master.